### PR TITLE
AGDIGGER-128 Disable Gradle daemon

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -66,6 +66,13 @@ RUN mkdir -p $HOME/.android && \
     chown -R 1001:0 $HOME && \
     chmod -R g+rw $HOME
 
+# disable Gradle daemon
+RUN mkdir -p $HOME/.gradle && \
+    echo "org.gradle.daemon=false" >> $HOME/.gradle/gradle.properties && \
+    chown -R 1001:0 $HOME/.gradle && \
+    chmod -R g+rw $HOME/.gradle
+
+
 COPY scripts/run-jnlp.sh /usr/local/bin/run-jnlp.sh 
 
 USER 1001


### PR DESCRIPTION
JIRA: https://issues.jboss.org/browse/AGDIGGER-128

## Verification:
Build the image. ex:
`docker build . -t my-temp-image`

Use that image (my-temp-image) in Jenkins Kubernetes Android pod template. Build an Android application.

You should see this in the logs:
```
To honour the JVM settings for this build a new JVM will be forked. Please consider using the daemon: 
```

Unlike stated in JIRA, GRADLE_USER_HOME doesn't have to be set.
