### PR TITLE
Add node 6 support and allow installation of node version via nvm

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ MAINTAINER AeroGear Team <https://aerogear.org/>
 
 #env vars
 ENV ANDROID_SLAVE_SDK_BUILDER=1.0.0 \
-    NODEJS_DEFAULT_VERSION=4.4 \
+    NODEJS_DEFAULT_VERSION=6.9.1 \
     CORDOVA_DEFAULT_VERSION=7.0.1 \
     GRADLE_VERSION=3.5 \
     ANDROID_HOME=/opt/android-sdk-linux \
@@ -37,9 +37,11 @@ RUN yum install -y \
 #install nvm and nodejs
 RUN curl -o- https://raw.githubusercontent.com/creationix/nvm/v0.33.2/install.sh | bash && \
     [ -s "$NVM_DIR/nvm.sh" ] && . "$NVM_DIR/nvm.sh" && \
+    echo 'export NVM_DIR=${NVM_DIR}' >> ${HOME}/.bashrc && \
     echo '[ -s "$NVM_DIR/nvm.sh" ] && . "$NVM_DIR/nvm.sh"' >> ${HOME}/.bashrc && \
     echo 'CI=Y' >> ${HOME}/.bashrc && \
     nvm install ${NODEJS_DEFAULT_VERSION} && \
+    chmod -R 777 ${NVM_DIR} && \
     npm install -g cordova@${CORDOVA_DEFAULT_VERSION}
 
 #install gradle
@@ -66,7 +68,7 @@ RUN mkdir -p $HOME/.android && \
     chown -R 1001:0 $HOME && \
     chmod -R g+rw $HOME
 
-COPY scripts/run-jnlp.sh /usr/local/bin/run-jnlp.sh 
+COPY scripts/run-jnlp.sh /usr/local/bin/run-jnlp.sh
 
 USER 1001
 WORKDIR /tmp


### PR DESCRIPTION
ping @odra 

Install node 6 latest by default and change perms on nvm dir to allow users to run `nvm install` in Jenkinsfile